### PR TITLE
Release 0.2.0 | feat: Made route handler threaded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,10 +236,11 @@ dependencies = [
 
 [[package]]
 name = "m_server"
-version = "0.1.3-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "log",
  "log4rs",
+ "threadpool",
 ]
 
 [[package]]
@@ -243,6 +250,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -431,6 +448,15 @@ checksum = "f0ec81c46e9eb50deaa257be2f148adf052d1fb7701cfd55ccfab2525280b70b"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "m_server"
-version = "0.1.4-alpha"
+version = "0.2.0-alpha"
 status = "alpha"
 edition = "2021"
-description = "A minimal HTTP server framework. ALPHA: NOT READY FOR PRODUCTION!"
+description = "A minimal HTTP server framework for delivering JSON data. \nALPHA: NOT READY FOR PRODUCTION!"
 license = "GPL-3.0-only"
 authors = ["Kyle Yannelli"]
 repository = "https://github.com/kyleyannelli/m_server"
@@ -16,3 +16,4 @@ readme = "README.md"
 [dependencies]
 log = "0.4.20"
 log4rs = "1.2.0"
+threadpool = "1.8.1"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # <img src="/assets/logo.png" alt="Logo" width="120" /> m_server
-Super minimal HTTP server framework written in Rust.
+Super minimal HTTP server framework for delivering JSON data; written in Rust.
 # Getting Started
 #### Below is a super basic example of creating a server and routes.
 ```rust
@@ -13,16 +13,17 @@ use m_server::{
 };
 
 // must be in the IP:PORT format!
-
 const BIND_ADDR: &str = "127.0.0.1:7878";
+// thread pool size for route handling
+const POOL_SIZE: usize = 50;
 
 fn main() {
   // creating a new HttpServer will instantly attempt to bind to the IP:PORT
   let http_server: HttpServer = HttpServer::new(self::BIND_ADDR);
-  let mut router: HttpRouter = HttpRouter::new();
+  let mut router: HttpRouter = HttpRouter::new(self::POOL_SIZE);
 
   // It is recommended to define the handlers in Controllers, rather than inline.
-  router.add_route(HttpRequestMethod::Get, "/person".to_string(), |mut http_request| {
+  router.add_route(HttpRequestMethod::Get, "/person", |mut http_request| {
     let json_data = "
     {
       \"name\": \"John Doe\",
@@ -32,7 +33,7 @@ fn main() {
     http_request.respond_with_body(HttpResponse::created(), json_data);
   });
   // example of responding without body
-  router.add_route(HttpRequestMethod::Delete, "/person".to_string(), |mut http_request| {
+  router.add_route(HttpRequestMethod::Delete, "/person", |mut http_request| {
     http_request.respond(HttpResponse::ok());
   });
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -1,35 +1,60 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::Arc,
+};
 
-use crate::http::{request::{HttpRequest, HttpRequestMethod}, response::HttpResponse};
+use threadpool::ThreadPool;
+
+use crate::http::{
+    request::{HttpRequest, HttpRequestMethod},
+    response::HttpResponse
+};
 
 pub struct HttpRouter {
-    routes: HashMap<(HttpRequestMethod, String), Box<dyn Fn(HttpRequest) + Send + Sync>>,
+    // Arc is an Atomic wrapper to make the HashMap thread safe
+    //  each thread will get a clone of the wrapped data to achieve this
+    routes: Arc<HashMap<(HttpRequestMethod, String), Box<dyn Fn(HttpRequest) + Send + Sync>>>,
+    pool: ThreadPool,
 }
 
 impl HttpRouter {
-    pub fn new() -> HttpRouter {
+    pub fn new(pool_size: usize) -> HttpRouter {
         HttpRouter {
-            routes: HashMap::new()
+            routes: Arc::new(HashMap::new()),
+            pool: ThreadPool::new(pool_size),
         }
     }
 
-    pub fn add_route<F>(&mut self, method: HttpRequestMethod, path: String, handler: F)
+    pub fn add_route<F>(&mut self, method: HttpRequestMethod, path: &str, handler: F)
     where
         F: Fn(HttpRequest) + 'static + Send + Sync,
     {
-        self.routes.insert((method, path), Box::new(handler));
+        let routes = match Arc::get_mut(&mut self.routes) {
+            Some(routes) => routes,
+            None => {
+                log::error!("Failed to create route! Unable to mutate routes object to add route.");
+                std::process::exit(1);
+            }
+        };
+        routes.insert((method, path.to_owned()), Box::new(handler));
     }
 
     pub fn handle_request(&self, mut request: HttpRequest) {
         let route_key: (HttpRequestMethod, String) = (request.route.method.clone() , request.route.path.clone());
-        if let Some(handler) = self.routes.get(&route_key) {
-            request.println_req();
-            handler(request);
-        }
-        else {
-            request.println_req();
-            request.respond(HttpResponse::not_found());
-        }
+        // here we have to clone the routes to access it inside of the thread pool, otherwise it's
+        //  an illegal move
+        let routes = self.routes.clone();
+
+        self.pool.execute(move || {
+            if let Some(handler) = routes.get(&route_key) {
+                request.println_req();
+                handler(request);
+            }
+            else {
+                request.println_req();
+                request.respond(HttpResponse::not_found());
+            }
+        });
     }
 }
 


### PR DESCRIPTION
HttpRouter will now take in a usize for the size of the thread pool. Requests are no longer sync.

# Features / Changes
- Requests are async
- Route names are now &str to avoid putting `.to_owned()` or `.to_string()` on your entries