### PR TITLE
fix: release branch should now publish

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: build-and-test
-    if: github.ref == 'refs/heads/release'
+    if: >
+      github.ref == 'refs/heads/release' ||
+      (github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'release')
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
ref for pr's are not going to just be "release" so using the event of base branch should work