### PR TITLE
v0.3.0-alpha | path regex

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: build-and-test
+    if: github.event_name == 'push'
     steps:
       - uses: actions/checkout@v3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "m_server"
-version = "0.2.0-alpha"
+version = "0.3.0-alpha"
 dependencies = [
  "log",
  "log4rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,8 +249,15 @@ version = "0.2.0-alpha"
 dependencies = [
  "log",
  "log4rs",
+ "regex",
  "threadpool",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "num-traits"
@@ -326,6 +342,35 @@ checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ryu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "m_server"
-version = "0.2.0-alpha"
+version = "0.3.0-alpha"
 status = "alpha"
 edition = "2021"
 description = "A minimal HTTP server framework for delivering JSON data. \nALPHA: NOT READY FOR PRODUCTION!"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ readme = "README.md"
 [dependencies]
 log = "0.4.20"
 log4rs = "1.2.0"
+regex = "1.10.2"
 threadpool = "1.8.1"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ fn main() {
   let mut router: HttpRouter = HttpRouter::new(self::POOL_SIZE);
 
   // It is recommended to define the handlers in Controllers, rather than inline.
-  router.add_route(HttpRequestMethod::Get, "/person", |mut http_request| {
+  router.add_route(HttpRequestMethod::Get, "/person/{person_id}", |mut http_request| {
     let json_data = "
     {
       \"name\": \"John Doe\",
@@ -33,7 +33,7 @@ fn main() {
     http_request.respond_with_body(HttpResponse::created(), json_data);
   });
   // example of responding without body
-  router.add_route(HttpRequestMethod::Delete, "/person", |mut http_request| {
+  router.add_route(HttpRequestMethod::Delete, "/person/{person_id}", |mut http_request| {
     http_request.respond(HttpResponse::ok());
   });
 

--- a/src/http/request.rs
+++ b/src/http/request.rs
@@ -30,6 +30,7 @@ impl std::fmt::Display for HttpRequestMethod {
     }
 }
 
+#[derive(Clone)]
 pub struct HttpRequestParser {
     raw_req: Vec<LineOrError>,
 }
@@ -86,6 +87,7 @@ impl HttpRequestParser {
     }
 }
 
+//#[derive(Clone)]
 pub struct HttpRequest {
     #[allow(dead_code)]
     pub raw_req: Vec<LineOrError>,

--- a/src/router.rs
+++ b/src/router.rs
@@ -10,10 +10,17 @@ use crate::http::{
     response::HttpResponse
 };
 
+use regex::Regex;
+
+struct RouteHandler {
+    regex: Regex,
+    handler: Box<dyn Fn(&HttpRequest) + Send + Sync>,
+}
+
 pub struct HttpRouter {
     // Arc is an Atomic wrapper to make the HashMap thread safe
     //  each thread will get a clone of the wrapped data to achieve this
-    routes: Arc<HashMap<(HttpRequestMethod, String), Box<dyn Fn(HttpRequest) + Send + Sync>>>,
+    routes: Arc<HashMap<HttpRequestMethod, Vec<RouteHandler>>>,
     pool: ThreadPool,
 }
 
@@ -27,37 +34,59 @@ impl HttpRouter {
 
     pub fn add_route<F>(&mut self, method: HttpRequestMethod, path: &str, handler: F)
     where
-        F: Fn(HttpRequest) + 'static + Send + Sync,
+        F: Fn(&HttpRequest) + 'static + Send + Sync,
     {
+        let regex_pattern = self.convert_path_to_regex(path);
+        let regex = Regex::new(&regex_pattern).unwrap();
+        let route_handler = RouteHandler {
+            regex,
+            handler: Box::new(handler),
+        };
         let routes = match Arc::get_mut(&mut self.routes) {
             Some(routes) => routes,
             None => {
-                log::error!("Failed to create route! Unable to mutate routes object to add route.");
+                log::error!("Failed to create route! Unable to mutate routes object to add route.\n\t Please report this error at https://github.com/kyleyannelli/m_server");
                 std::process::exit(1);
             }
         };
-        routes.insert((method, path.to_owned()), Box::new(handler));
+        routes.entry(method).or_insert(Vec::<RouteHandler>::new()).push(route_handler);
     }
 
-    pub fn handle_request(&self, mut request: HttpRequest) {
-        let route_key: (HttpRequestMethod, String) = (request.route.method.clone() , request.route.path.clone());
+    pub fn handle_request(&self, mut request: &HttpRequest) {
         // here we have to clone the routes to access it inside of the thread pool, otherwise it's
         //  an illegal move
         let routes = self.routes.clone();
+        let route_path = request.route.path.clone();
 
         self.pool.execute(move || {
-            if let Some(handler) = routes.get(&route_key) {
-                request.println_req();
-                handler(request);
-            }
-            else {
-                request.println_req();
-                request.respond(HttpResponse::not_found());
+            if let Some(handlers) = routes.get(&request.route.method) {
+                for handler in handlers {
+                    if handler.regex.is_match(&route_path) {
+                        (handler.handler)(request);
+                    }
+                }
             }
         });
     }
+
+    fn convert_path_to_regex(&self, path: &str) -> String {
+        let mut regex_pattern = "^".to_string();
+        for segment in path.split('/') {
+            regex_pattern.push_str("/");
+            if segment.starts_with("{") && segment.ends_with("}") {
+                let param_name = &segment[1..segment.len()-1];
+                regex_pattern.push_str(&format!("(?P<{}>[^/]+)", param_name));
+            }
+            else {
+                regex_pattern.push_str(segment);
+            }
+        }
+        regex_pattern.push_str("$");
+        return regex_pattern.clone();
+    }
 }
 
+#[derive(Clone)]
 pub struct HttpRoute {
     pub method: HttpRequestMethod,
     pub path: String,

--- a/src/router.rs
+++ b/src/router.rs
@@ -60,6 +60,7 @@ impl HttpRouter {
             let mut req = request.lock().unwrap();
             if let Some(handlers) = routes.get(&req.route.method) {
                 for handler in handlers {
+                    println!("HTTPREQ {} HANDLER {}", &req.route.path, handler.regex.to_string());
                     if handler.regex.is_match(&req.route.path) {
                         // we no longer want the req at this point, as we pass to the handler its
                         // out of scope
@@ -83,7 +84,9 @@ impl HttpRouter {
     fn convert_path_to_regex(&self, path: &str) -> String {
         let mut regex_pattern = "^".to_string();
         for segment in path.split('/') {
-            regex_pattern.push_str("/");
+            if !segment.is_empty() {
+                regex_pattern.push_str("/");
+            }
             if segment.starts_with("{") && segment.ends_with("}") {
                 let param_name = &segment[1..segment.len()-1];
                 regex_pattern.push_str(&format!("(?P<{}>[^/]+)", param_name));

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,7 +33,7 @@ impl HttpServer {
                     let http_req: HttpRequest = HttpRequest::new(result);
                     // commenting this out until router impl is done
                     // Self::handle_connection(http_req);
-                    router.handle_request(http_req);
+                    router.handle_request(&http_req);
                 },
                 Err(error) => match error.kind() {
                     std::io::ErrorKind::WouldBlock => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,4 +1,4 @@
-use std::net::TcpListener;
+use std::{net::TcpListener, sync::{Mutex, Arc}};
 
 use crate::{router::HttpRouter, http::request::HttpRequest, logger};
 
@@ -31,9 +31,10 @@ impl HttpServer {
             match stream_res {
                 Ok(result) => {
                     let http_req: HttpRequest = HttpRequest::new(result);
+                    let wrapped_req = Arc::new(Mutex::new(http_req));
                     // commenting this out until router impl is done
                     // Self::handle_connection(http_req);
-                    router.handle_request(&http_req);
+                    router.handle_request(wrapped_req);
                 },
                 Err(error) => match error.kind() {
                     std::io::ErrorKind::WouldBlock => {


### PR DESCRIPTION
Path regexs allow for paths such as `/person/{person_id}` and `/person/{person_id}/settings`. Feature tested with postman, again, testing will  be done once functionality is more concrete as things are constantly changing